### PR TITLE
Fix problems with dockerfiles building the image with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM registry.suse.com/bci/python:3.10
 
+RUN mkdir /pms
 COPY requirements.txt /pms
 WORKDIR /pms
-RUN pip3.10 install -r requirements.txt && rm -rf /var/cache
+RUN zypper -n in python310-devel gcc gcc-c++ && pip3.10 install -r requirements.txt && rm -rf /var/cache
 COPY dumper.py ./db ./redmine /pms
 
 ENTRYPOINT ["sh", "-c"]

--- a/Dockerfile_test
+++ b/Dockerfile_test
@@ -1,7 +1,8 @@
 FROM registry.suse.com/bci/python:3.10
 
+RUN mkdir /pms
 COPY requirements_test.txt requirements.txt /pms
 WORKDIR /pms
-RUN pip3.10 install -r requirements_test.txt && rm -rf /var/cache
+RUN zypper -n in python310-devel gcc gcc-c++ && pip3.10 install -r requirements_test.txt && rm -rf /var/cache
 
 ENTRYPOINT ["sh", "-c"]


### PR DESCRIPTION
The first problem is that docker copies requirements.txt as pms (file) "COPY requirements.txt /pms"

Then the error appears:
```
=> ERROR [3/4] WORKDIR /pms                                                                                                                                                                                                                                                                                                                                         0.0s
------
 > [3/4] WORKDIR /pms:
------
mkdir /var/lib/docker/overlay2/6yafkj0xetrk3jlemh8ki8841/merged/pms: not a directory
```

The second problem is that in some enviroments SQLAlcheme needs to be compiled
```
-grecord-gcc-switches -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables
```