### PR TITLE
Use subcommands instead of argument on dumper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,207 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Emacs
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+TAGS
+tags
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+# Vi
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+# Others
 deprecated
-venv
-__pycache__
 redmine/config.py
+bsc/config.py
 *.sql
 notes.txt

--- a/dumper.py
+++ b/dumper.py
@@ -1,17 +1,60 @@
-#!/usr/local/bin/python3
-import logging
+#!/usr/bin/env python3
 import argparse
+import logging
+import logging.config
+
 from redmine.redmine_dumper import RedmineDumper
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '--source', help="Source from where ticket will be dumped. Possible values: (redmine|bugzilla). \
-            Default: redmine", default='redmine')
-    parser.add_argument('--database', help="SQLite file path", required=True)
-    parser.add_argument('--project', help="Project name")
-    parser.add_argument('-v', action='store_true', help='increase output verbosity')
+    parser.add_argument('-v',
+                        action='store_true',
+                        help='increase output verbosity')
+    subparsers = parser.add_subparsers(dest='source', required=True)
+    redmine_parser = subparsers.add_parser('redmine', help='redmine help')
+    redmine_parser.add_argument('--project', help="Project name")
+    redmine_parser.add_argument('--database',
+                                help="SQLite file path",
+                                required=True)
+
+    bugzilla_parser = subparsers.add_parser('bugzilla', help='bugzilla help')
+    bugzilla_parser.add_argument('-P', '--prod', metavar='string', type=str,
+                                 help='Bugzilla product value')
+    bugzilla_parser.add_argument('-s', '--status', metavar='string', type=str,
+                                 choices=['NEW',
+                                          'CONFIRMED',
+                                          'IN_PROGRESS',
+                                          'RESOLVED'],
+                                 help='What status should be the bugs')
+    bugzilla_parser.add_argument('-S', '--severity',
+                                 metavar='string', type=str,
+                                 choices=['Critical',
+                                          'Major',
+                                          'Normal',
+                                          'Minor',
+                                          'Enhancement'],
+                                 help='what severity should the query use')
+    bugzilla_parser.add_argument('-p', '--priority',
+                                 metavar='string', type=str,
+                                 choices=['P0 - Crit Sit',
+                                          'P1 - Urgent',
+                                          'P2 - High',
+                                          'P3 - Medium',
+                                          'P4 - Low',
+                                          'P5 - None'],
+                                 help='What priority should we query')
+    bugzilla_parser.add_argument('-n', '--range',
+                                 metavar='int', type=int,
+                                 default=max,
+                                 help='An integer value which will give the \
+                                 range of the query since current date')
+    bugzilla_parser.add_argument('-x', '--exec', nargs='*',
+                                 help='List of bsc_queries to run')
+    bugzilla_parser.add_argument('-l', action='store_true',
+                                 dest='listqueries', required=False,
+                                 help='List the metric queries \
+                                 which can be used')
     args = parser.parse_args()
 
     if args.v is True:
@@ -23,9 +66,11 @@ def main():
 
     if args.source == "redmine":
         if args.project is None:
-            raise TypeError("dumper.py: error: the following arguments are required: --project when source is redmine")
+            raise TypeError("dumper.py: error: the following arguments are \
+            required: --project when source is redmine")
 
-        logger.info("Dumping from %s (project: %s) to database %s", args.source, args.project, args.database)
+        logger.info("Dumping from %s (project: %s) to database %s",
+                    args.source, args.project, args.database)
         dumper = RedmineDumper(args.database, logging_level)
         dumper.dump_to_db(args.project)
     else:


### PR DESCRIPTION
Refactor argparser to make separate logic into separate group of subcommands which each takes its own arguments. This is more clear representation of various implentations and easy to understand and extend without breaking individual components or conflicts between each other